### PR TITLE
Update BUILD.md (Visual Studio XP support)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -192,20 +192,24 @@ Compiling the source code using Visual Studio (Windows)
 You can build the source code with Visual Studio 2017, 2019, and 2022.
 (The code currently cannot be built with Visual Studio 2015)
 The executables will work on 32-bit and 64-bit Windows Vista or higher.
-If you want the executables to work on Windows XP, you can patch the PE header
-using a tool included in the source code.
-
-```./contrib/windows/installer/PatchPE.exe path-to-your-exe-file/dosbox-x.exe```
 
 Use the ```./vs/dosbox-x.sln``` "solution" file and build the source code.
 You will need the DirectX 2010 SDK for Direct3D9 support.
 
 By default the targeted platform is v142 (Visual Studio 2019).
-For building the source code in Visual Studio 2017 or 2022,
+To build the source code on Visual Studio 2017 or 2022,
 you may change the platform toolset to v141 or v143 respectively.
 For Visual Studio 2017, you have to set ``WindowsTargetPlatformVersion`` to whatever
 Windows SDK version installed in your PC, for example ``10.0.22000.0``.
-(Visual Studio 2019 and beyond will pick the latest Windows SDK version if you set the value to `10.0`)
+(Visual Studio 2019 and beyond will pick the latest Windows SDK version installed
+if you set the value to `10.0`)
+
+To build executables that will work on Windows XP,
+you have to change the target platform to v141 (Visual Studio 2017).
+After the build is completed, you have to patch the PE header of the executable using
+a tool included in the source code.
+
+```./contrib/windows/installer/PatchPE.exe path-to-your-exe-file/dosbox-x.exe```
 
 Libraries such as SDL, freetype, libpdcurses, libpng and zlib are already included,
 and as of DOSBox-X 0.83.6 support for FluidSynth MIDI Synthesizer is also included


### PR DESCRIPTION
The current `BUILD.md` doesn't mention that platform toolset has to be changed to v141 in order to build executable that can run on Windows XP.
This PR adds such explanation.